### PR TITLE
Fix image name at docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a simplified version of [ancypwn](https://github.com/Escapingbug/ancypwn
 Contains only the container management parts.
 - run     
   run a pwn environments using containers.  
-  usage:  `swpwn run --ubutnu 20.04 --priv .`
+  usage:  `swpwn run --ubuntu 20.04 --priv .`
 - list    
   list all runing container.                
   usage:  `swpwn list`

--- a/swpwn/src/swpwn.py
+++ b/swpwn/src/swpwn.py
@@ -254,7 +254,7 @@ def run_pwn(args):
                 }
             }
         running_container = container.run(
-            'swpwn:{}'.format(ubuntu),
+            'beswing/swpwn:{}'.format(ubuntu),
             '/bin/bash',
             cap_add=['SYS_ADMIN', 'SYS_PTRACE'],
             detach=True,


### PR DESCRIPTION
The image name causes the following error:
```
docker.errors.ImageNotFound: 404 Client Error for http+docker://localhost/v1.41/containers/create: Not Found ("No such image: swpwn:20.04")
```

I've changed it from `swpwn` to `beswing/swpwn` which fixed the issue.

At the same time, I've fixed a small typo in README.MD.