### PR TITLE
Disable default seccomp profile

### DIFF
--- a/swpwn/src/swpwn.py
+++ b/swpwn/src/swpwn.py
@@ -257,6 +257,7 @@ def run_pwn(args):
             'beswing/swpwn:{}'.format(ubuntu),
             '/bin/bash',
             cap_add=['SYS_ADMIN', 'SYS_PTRACE'],
+            security_opt=['seccomp:unconfined'],
             detach=True,
             tty=True,
             volumes=volumes,


### PR DESCRIPTION
The default profile prevents pwndbg from disabling aslr. Instead of
running the container as privileged, it is better to disable default
seccomp profile.

There may be a more elegant solution like using a custom profile by tweaking the default one so that pwndbg can disable aslr, but I am not sure which settings need to be tweaked for now.