### PR TITLE
Add radare2 to images

### DIFF
--- a/build/ubuntu16.04/dockerfile
+++ b/build/ubuntu16.04/dockerfile
@@ -13,6 +13,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
     libc6-dbg:i386 \
     gcc-multilib \
     gdb-multiarch \
+    radare2 \
     gcc \
     wget \
     curl \

--- a/build/ubuntu18.04/dockerfile
+++ b/build/ubuntu18.04/dockerfile
@@ -12,6 +12,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
     libc6-dbg:i386 \
     gcc-multilib \
     gdb-multiarch \
+    radare2 \
     gcc \
     wget \
     curl \

--- a/build/ubuntu19.10/dockerfile
+++ b/build/ubuntu19.10/dockerfile
@@ -13,6 +13,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
     libc6-dbg:i386 \
     gcc-multilib \
     gdb-multiarch \
+    radare2 \
     gcc \
     wget \
     curl \

--- a/build/ubuntu20.04/dockerfile
+++ b/build/ubuntu20.04/dockerfile
@@ -14,6 +14,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
     libc6-dbg:i386 \
     gcc-multilib \
     gdb-multiarch \
+    radare2 \
     gcc \
     wget \
     curl \

--- a/build/ubuntu20.10/dockerfile
+++ b/build/ubuntu20.10/dockerfile
@@ -13,6 +13,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
     libc6-dbg:i386 \
     gcc-multilib \
     gdb-multiarch \
+    radare2 \
     gcc \
     wget \
     curl \


### PR DESCRIPTION
I think radare2 is often times useful to have in the toolbox. I was able to find a gadget with radare2 when tools like ROPgadget, ropper, etc. all failed to find it. It also helps to analyze weird architectures like gameboy roms.