### PR TITLE
Run and attach with zsh instead of bash

### DIFF
--- a/swpwn/src/swpwn.py
+++ b/swpwn/src/swpwn.py
@@ -170,7 +170,7 @@ def _read_container_name():
 
 def _attach_interactive(name):
 
-    cmd = "docker exec -it {} '/bin/bash'".format(
+    cmd = "docker exec -it {} '/bin/zsh'".format(
             name,
         )
     ColorWrite.yellow(
@@ -255,7 +255,7 @@ def run_pwn(args):
             }
         running_container = container.run(
             'beswing/swpwn:{}'.format(ubuntu),
-            '/bin/bash',
+            '/bin/zsh',
             cap_add=['SYS_ADMIN', 'SYS_PTRACE'],
             security_opt=['seccomp:unconfined'],
             detach=True,


### PR DESCRIPTION
In my previous PR, I forgot to change these lines. Thus, currently swpwn still uses bash even though zsh is installed.