### PR TITLE
Always use latest ubuntu version as default

### DIFF
--- a/swpwn/src/swpwn.py
+++ b/swpwn/src/swpwn.py
@@ -210,7 +210,7 @@ def run_pwn(args):
     # port = args.port if not args.port is None else 15111
 
     if not args.ubuntu:
-        ubuntu = '18.04'
+        ubuntu = SUPPORTED_UBUNTU_VERSION[-1]
     else:
         # check for unsupported ubuntu version
         if args.ubuntu not in SUPPORTED_UBUNTU_VERSION:


### PR DESCRIPTION
The default ubuntu version is currently set to `18.04`. Since we only have LTS releases in `SUPPORTED_UBUNTU_VERSIONS`, I think we can safely use the latest LTS version as default.