### PR TITLE
Upgrade to docker/build-push-action@v2

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -15,13 +15,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: build and push ubuntu ${{ matrix.VERSION }}
-        uses: docker/build-push-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Dockerhub
         with:
           username: beswing
           password: ${{secrets.DOCKER_HUB_TOKEN}}
-          dockerfile: ./build/ubuntu${{ matrix.VERSION }}/dockerfile
+
+      - name: Build and push ubuntu ${{ matrix.VERSION }}
+        uses: docker/build-push-action@v2
+        with:
+          file: ./build/ubuntu${{ matrix.VERSION }}/dockerfile
           repository: beswing/swpwn
-          tags: ${{ matrix.VERSION }}
-          tag_with_ref: true
+          tags: beswing/swpwn:${{ matrix.VERSION }}
           push: true


### PR DESCRIPTION
We had the following warnings in our workflow:

![image](https://user-images.githubusercontent.com/32958854/127319023-cee1340f-c542-4423-aa29-0419213769cd.png)

I have followed [this](https://github.com/docker/build-push-action/blob/master/UPGRADE.md) to make necessary changes. I don't think we need to tag with refs, so I removed it. If required, we can have it again, but we already use version matrix to tag each image.